### PR TITLE
Create a tool window programatically

### DIFF
--- a/samples/DockMvvmSample/ViewModels/MainWindowViewModel.cs
+++ b/samples/DockMvvmSample/ViewModels/MainWindowViewModel.cs
@@ -1,10 +1,13 @@
 ﻿using System.Diagnostics;
+using System.Linq;
 using System.Windows.Input;
-using DockMvvmSample.Models;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using Dock.Model.Controls;
 using Dock.Model.Core;
+using Dock.Model.Mvvm.Controls;
+using DockMvvmSample.Models;
+using DockMvvmSample.ViewModels.Tools;
 
 namespace DockMvvmSample.ViewModels;
 
@@ -20,6 +23,8 @@ public class MainWindowViewModel : ObservableObject
     }
 
     public ICommand NewLayout { get; }
+
+    public ICommand NewTool { get; }
 
     public MainWindowViewModel()
     {
@@ -38,6 +43,7 @@ public class MainWindowViewModel : ObservableObject
         }
 
         NewLayout = new RelayCommand(ResetLayout);
+        NewTool = new RelayCommand(CreateNewTool);
     }
 
     private void DebugFactoryEvents(IFactory factory)
@@ -162,6 +168,23 @@ public class MainWindowViewModel : ObservableObject
         {
             Layout = layout;
             _factory?.InitLayout(layout);
+        }
+    }
+
+    private void CreateNewTool()
+    {
+        if (Layout?.Factory is { } factory)
+        {
+            foreach (var dockable in factory.VisibleDockableControls.ToArray())
+            {
+                if (dockable.Key is ToolDock dock && dock.Alignment == Alignment.Right)
+                {
+                    var newToolModel = new MenuToolViewModel();
+                    Layout.Factory.AddDockable(dock, newToolModel);
+                    Layout.Factory.SetActiveDockable(newToolModel);
+                    break;
+                }
+            }
         }
     }
 }

--- a/samples/DockMvvmSample/ViewModels/Tools/MenuToolViewModel.cs
+++ b/samples/DockMvvmSample/ViewModels/Tools/MenuToolViewModel.cs
@@ -1,0 +1,13 @@
+﻿using Dock.Model.Mvvm.Controls;
+
+namespace DockMvvmSample.ViewModels.Tools;
+
+public class MenuToolViewModel : Tool
+{
+    public MenuToolViewModel()
+    {
+        Id = "Id of MenuTool";
+        Title = "MenuTool";
+        Context = "Context of MenuTool";
+    }
+}

--- a/samples/DockMvvmSample/Views/MainView.axaml
+++ b/samples/DockMvvmSample/Views/MainView.axaml
@@ -21,6 +21,7 @@
     <Menu Grid.Row="0" Grid.Column="0" VerticalAlignment="Top">
       <MenuItem Header="_File">
         <MenuItem Header="_New Layout" Command="{Binding NewLayout}" />
+        <MenuItem Header="New Tool" Command="{Binding NewTool}" />
       </MenuItem>
       <MenuItem Header="_Window" DataContext="{Binding Layout}">
         <MenuItem Header="_Exit Windows" Command="{Binding ExitWindows}" />

--- a/samples/DockMvvmSample/Views/Tools/MenuToolView.axaml
+++ b/samples/DockMvvmSample/Views/Tools/MenuToolView.axaml
@@ -1,0 +1,17 @@
+﻿<UserControl x:Class="DockMvvmSample.Views.Tools.MenuToolView"
+             xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:vm="using:DockMvvmSample.ViewModels.Tools"
+             mc:Ignorable="d"
+             d:DesignWidth="300" d:DesignHeight="400"
+             x:DataType="vm:MenuToolViewModel" x:CompileBindings="True">
+  <Grid Focusable="True">
+    <StackPanel VerticalAlignment="Center" HorizontalAlignment="Center">
+      <TextBlock Text="{Binding Id}" Padding="2" />
+      <TextBlock Text="{Binding Title}" Padding="2" />
+      <TextBlock Text="{Binding Context}" Padding="2" />
+    </StackPanel>
+  </Grid>
+</UserControl>

--- a/samples/DockMvvmSample/Views/Tools/MenuToolView.axaml.cs
+++ b/samples/DockMvvmSample/Views/Tools/MenuToolView.axaml.cs
@@ -1,0 +1,17 @@
+﻿using Avalonia.Controls;
+using Avalonia.Markup.Xaml;
+
+namespace DockMvvmSample.Views.Tools;
+
+public partial class MenuToolView : UserControl
+{
+    public MenuToolView()
+    {
+        InitializeComponent();
+    }
+
+    private void InitializeComponent()
+    {
+        AvaloniaXamlLoader.Load(this);
+    }
+}

--- a/samples/DockXamlSample/MainView.axaml
+++ b/samples/DockXamlSample/MainView.axaml
@@ -14,6 +14,8 @@
         <MenuItem x:Name="FileSaveLayout" Header="_Save layout..." Click="FileSaveLayout_OnClick" />
         <Separator/>
         <MenuItem x:Name="FileCloseLayout" Header="_Close layout" Click="FileCloseLayout_OnClick" />
+        <Separator/>
+        <MenuItem x:Name="FileNewTool" Header="New tool window" Click="FileNewTool_OnClick" />
       </MenuItem>
     </Menu>
 

--- a/samples/DockXamlSample/MainView.axaml.cs
+++ b/samples/DockXamlSample/MainView.axaml.cs
@@ -2,17 +2,16 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Text.Json;
 using System.Threading.Tasks;
 using Avalonia.Collections;
 using Avalonia.Controls;
+using Avalonia.Controls.Templates;
 using Avalonia.Interactivity;
 using Avalonia.Markup.Xaml;
 using Avalonia.Platform.Storage;
 using Dock.Avalonia.Controls;
 using Dock.Model;
 using Dock.Model.Avalonia.Controls;
-using Dock.Model.Avalonia.Json;
 using Dock.Model.Core;
 using Dock.Serializer;
 
@@ -171,6 +170,51 @@ public partial class MainView : UserControl
     private void FileCloseLayout_OnClick(object? sender, RoutedEventArgs e)
     {
         CloseLayout();
+    }
+
+    /// <summary>
+    /// Called if the user chooses File->New tool from the main menu.
+    /// A new tool is added to the right side (but only if it exists).
+    /// </summary>
+    /// <param name="sender">The sender.</param>
+    /// <param name="e">The <see cref="RoutedEventArgs"/> instance containing the event data.</param>
+    private void FileNewTool_OnClick(object? sender, RoutedEventArgs e)
+    {
+        if (this.FindControl<DockControl>("Dock") is { } dock &&
+            dock.Factory is { } factory)
+        {
+            foreach (var dockable in factory.VisibleDockableControls.ToArray())
+            {
+                if (dockable.Key is ToolDock tooldock && tooldock.Alignment == Alignment.Right)
+                {
+                    // create a new ViewModel
+                    var newToolModel = new Tool();
+                    newToolModel.Id = "ID of MenuTool";
+                    newToolModel.Title = "MenuTool";
+
+                    // provide the ViewModel with a method to create its view
+                    newToolModel.Content = new Func<object, TemplateResult<Control>>((data) => GetViewForViewModel(newToolModel));
+
+                    // add the view model
+                    factory.AddDockable(tooldock, newToolModel);
+                    factory.SetActiveDockable(newToolModel);
+                    break;
+                }
+
+            }
+        }
+    }
+
+    /// <summary>
+    /// Gets the view for the given view model.
+    /// </summary>
+    /// <param name="viewModel">The view model.</param>
+    /// <returns></returns>
+    private TemplateResult<Control> GetViewForViewModel(object viewModel)
+    {
+        var view = new MenuToolView() { DataContext = viewModel };
+        var result = new TemplateResult<Control>((Control)view, null);
+        return result;
     }
 }
 

--- a/samples/DockXamlSample/MenuToolView.axaml
+++ b/samples/DockXamlSample/MenuToolView.axaml
@@ -1,0 +1,16 @@
+﻿<UserControl x:Class="DockXamlSample.MenuToolView"
+             xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             mc:Ignorable="d"
+             d:DesignWidth="300" d:DesignHeight="400"
+             >
+  <Grid Focusable="True">
+    <StackPanel VerticalAlignment="Center" HorizontalAlignment="Center">
+      <TextBlock Text="{Binding Id}" Padding="2" />
+      <TextBlock Text="{Binding Title}" Padding="2" />
+      <TextBlock Text="{Binding Context}" Padding="2" />
+    </StackPanel>
+  </Grid>
+</UserControl>

--- a/samples/DockXamlSample/MenuToolView.axaml.cs
+++ b/samples/DockXamlSample/MenuToolView.axaml.cs
@@ -1,0 +1,17 @@
+﻿using Avalonia.Controls;
+using Avalonia.Markup.Xaml;
+
+namespace DockXamlSample;
+
+public partial class MenuToolView : UserControl
+{
+    public MenuToolView()
+    {
+        InitializeComponent();
+    }
+
+    private void InitializeComponent()
+    {
+        AvaloniaXamlLoader.Load(this);
+    }
+}


### PR DESCRIPTION
This is extending DockXamlSample and DockMvvmSample with a main menu item 'New Tool', which searches for a ToolDock on the right, and if found, adds a new Tool view model to it.